### PR TITLE
Add compatibility with Ruby 2.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.4
           bundler-cache: true
       - run: bundle exec rubocop

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.3 ]
+        ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.3 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.4
   NewCops: enable
 
 RSpec/ImplicitExpect:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 ### Changed
+- Add compatibility with Ruby 2.4 ([#21](https://github.com/opensearch-project/opensearch-ruby-aws-sigv4/pull/21))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -18,16 +18,18 @@ gem 'bundler', '~> 2'
 gem 'rake', '~> 13'
 gem 'yard', '~> 0.9'
 
-if RUBY_VERSION.start_with?('2.4')
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4') && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
   gem 'rubocop', '~> 1.12.1'
   gem 'rubocop-rake', '~> 0.5.1'
   gem 'rubocop-rspec', '~> 2.2.0'
   gem 'simplecov', '~> 0.18.5'
 else
-  gem 'rubocop', '~> 1.28'
-  gem 'rubocop-rake', '~> 0.6'
-  gem 'rubocop-rspec', '~> 2.10'
-  gem 'simplecov', '~> 0.22'
+  # We need to disable Bundler/DuplicatedGem only because of rubocop 1.12.1.
+  # Rubocop 1.28 allows conditional declaration of gems.  See: https://docs.rubocop.org/rubocop/cops_bundler.html#bundlerduplicatedgem
+  gem 'rubocop', '~> 1.28' # rubocop:disable Bundler/DuplicatedGem, Lint/RedundantCopDisableDirective
+  gem 'rubocop-rake', '~> 0.6' # rubocop:disable Bundler/DuplicatedGem, Lint/RedundantCopDisableDirective
+  gem 'rubocop-rspec', '~> 2.10' # rubocop:disable Bundler/DuplicatedGem, Lint/RedundantCopDisableDirective
+  gem 'simplecov', '~> 0.22' # rubocop:disable Bundler/DuplicatedGem, Lint/RedundantCopDisableDirective
 end
 
 gem 'rspec', '~> 3'

--- a/Gemfile
+++ b/Gemfile
@@ -18,12 +18,19 @@ gem 'bundler', '~> 2'
 gem 'rake', '~> 13'
 gem 'yard', '~> 0.9'
 
-gem 'rubocop', '~> 1.28'
-gem 'rubocop-rake', '~> 0.6'
-gem 'rubocop-rspec', '~> 2.10'
+if RUBY_VERSION.start_with?('2.4')
+  gem 'rubocop', '~> 1.12.1'
+  gem 'rubocop-rake', '~> 0.5.1'
+  gem 'rubocop-rspec', '~> 2.2.0'
+  gem 'simplecov', '~> 0.18.5'
+else
+  gem 'rubocop', '~> 1.28'
+  gem 'rubocop-rake', '~> 0.6'
+  gem 'rubocop-rspec', '~> 2.10'
+  gem 'simplecov', '~> 0.22'
+end
 
 gem 'rspec', '~> 3'
-gem 'simplecov', '~> 0.22'
 gem 'timecop', '~> 0.9'
 
 gem 'pry', '~> 0.14'

--- a/opensearch-aws-sigv4.gemspec
+++ b/opensearch-aws-sigv4.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
     s.cert_chain  = ['.github/opensearch-rubygems.pem']
   end
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'aws-sigv4', '~> 1'
   s.add_dependency 'opensearch-ruby', '>= 1.0.1'


### PR DESCRIPTION
As proposed in issue #19, make the gem compatible with Ruby 2.4.
I left _runtime_ dependencies untouched.
I changed the _development_ dependencies gems only for Ruby 2.4, and left them unchanged for all other versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
