### PR TITLE
Fix broken links to opensearch-ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The `opensearch-aws-sigv4` library provides an AWS Sigv4 client for connecting to [Amazon OpenSearch Service](https://docs.aws.amazon.com/opensearch-service/index.html).
 
-This library is an AWS Sigv4 wrapper for [`opensearch-ruby`](https://github.com/opensearch-project/opensearch-ruby/tree/main/opensearch-ruby), which is a Ruby client for OpenSearch. The `OpenSearch::Aws::Sigv4Client`, therefore, has all features of `OpenSearch::Client`.
+This library is an AWS Sigv4 wrapper for [`opensearch-ruby`](https://github.com/opensearch-project/opensearch-ruby/tree/main), which is a Ruby client for OpenSearch. The `OpenSearch::Aws::Sigv4Client`, therefore, has all features of `OpenSearch::Client`.
 
 ## Compatibility
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -23,7 +23,7 @@ bundle install
 
 ## Usage
 
-This library is an AWS Sigv4 wrapper for [`opensearch-ruby`](https://github.com/opensearch-project/opensearch-ruby/tree/main/opensearch-ruby), which is a Ruby client for OpenSearch. The `OpenSearch::Aws::Sigv4Client`, therefore, has all features of `OpenSearch::Client`.
+This library is an AWS Sigv4 wrapper for [`opensearch-ruby`](https://github.com/opensearch-project/opensearch-ruby/tree/main), which is a Ruby client for OpenSearch. The `OpenSearch::Aws::Sigv4Client`, therefore, has all features of `OpenSearch::Client`.
 
 ### Amazon OpenSearch Service
 To sign requests for the Amazon OpenSearch Service:

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -64,7 +64,7 @@
 
 <p>The <code>opensearch-aws-sigv4</code> library provides an AWS Sigv4 client for connecting to <a href="https://docs.aws.amazon.com/opensearch-service/index.html">Amazon OpenSearch Service</a>.</p>
 
-<p>This library is an AWS Sigv4 wrapper for href="https://github.com/opensearch-project/opensearch-ruby/tree/main/opensearch-ruby"></a>, which is a Ruby client for OpenSearch. The <code>OpenSearch::Aws::Sigv4Client</code>, therefore, has all features of <code>OpenSearch::Client</code>.</p>
+<p>This library is an AWS Sigv4 wrapper for href="https://github.com/opensearch-project/opensearch-ruby/tree/main"></a>, which is a Ruby client for OpenSearch. The <code>OpenSearch::Aws::Sigv4Client</code>, therefore, has all features of <code>OpenSearch::Client</code>.</p>
 
 <h2 id="label-Compatibility">Compatibility</h2>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,7 +64,7 @@
 
 <p>The <code>opensearch-aws-sigv4</code> library provides an AWS Sigv4 client for connecting to <a href="https://docs.aws.amazon.com/opensearch-service/index.html">Amazon OpenSearch Service</a>.</p>
 
-<p>This library is an AWS Sigv4 wrapper for href="https://github.com/opensearch-project/opensearch-ruby/tree/main/opensearch-ruby"></a>, which is a Ruby client for OpenSearch. The <code>OpenSearch::Aws::Sigv4Client</code>, therefore, has all features of <code>OpenSearch::Client</code>.</p>
+<p>This library is an AWS Sigv4 wrapper for href="https://github.com/opensearch-project/opensearch-ruby/tree/main"></a>, which is a Ruby client for OpenSearch. The <code>OpenSearch::Aws::Sigv4Client</code>, therefore, has all features of <code>OpenSearch::Client</code>.</p>
 
 <h2 id="label-Compatibility">Compatibility</h2>
 


### PR DESCRIPTION
### Description
Fix broken links to opensearch-ruby project.

### Issues Resolved
Link Checker workflow was failing because of broken links.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
