### PR TITLE
USER_GUIDE: fix require hyphen to underscore

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -29,7 +29,7 @@ This library is an AWS Sigv4 wrapper for [`opensearch-ruby`](https://github.com/
 To sign requests for the Amazon OpenSearch Service:
 
 ```ruby
-require 'opensearch-aws-sigv4'
+require 'opensearch_aws_sigv4'
 require 'aws-sigv4'
 
 signer = Aws::Sigv4::Signer.new(service: 'es', # signing service name, use "aoss" for OpenSearch Serverless

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -29,7 +29,7 @@ This library is an AWS Sigv4 wrapper for [`opensearch-ruby`](https://github.com/
 To sign requests for the Amazon OpenSearch Service:
 
 ```ruby
-require 'opensearch_aws_sigv4'
+require 'opensearch-aws-sigv4'
 require 'aws-sigv4'
 
 signer = Aws::Sigv4::Signer.new(service: 'es', # signing service name, use "aoss" for OpenSearch Serverless

--- a/lib/opensearch-aws-sigv4.rb
+++ b/lib/opensearch-aws-sigv4.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Naming/FileName
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to
@@ -108,3 +109,4 @@ module OpenSearch
     end
   end
 end
+# rubocop:enable Naming/FileName

--- a/lib/opensearch_aws_sigv4.rb
+++ b/lib/opensearch_aws_sigv4.rb
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+# frozen_string_literal: true
+
+require 'opensearch-aws-sigv4'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@
 
 # frozen_string_literal: true
 
-require_relative '../lib/opensearch_aws_sigv4'
+require_relative '../lib/opensearch-aws-sigv4'
 require 'rspec'
 
 OPENSEARCH_URL = ENV.fetch('TEST_OPENSEARCH_SERVER', nil) || "http://localhost:#{ENV.fetch('PORT', nil) || 9200}"


### PR DESCRIPTION
### Description
There is a typo in the USER_GUIDE, `require 'opensearch-aws-sigv4'` gives the error `LoadError: cannot load such file -- opensearch-aws-sigv4`, because the file name has underscores, not hyphens.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
