### PR TITLE
Pass exact signed body to perform_request to prevent Sigv4 mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Pass exact signed body to perform_request to prevent Sigv4 mismatch ([#24](https://github.com/opensearch-project/opensearch-ruby-aws-sigv4/pull/24))
 ### Security
 
 ## [1.2.0]

--- a/lib/opensearch-aws-sigv4.rb
+++ b/lib/opensearch-aws-sigv4.rb
@@ -67,7 +67,7 @@ module OpenSearch
         headers = (headers || {}).merge(signature.headers)
 
         log_signature_info(signature)
-        super(method, path, params, body, headers)
+        super(method, path, params, signature_body, headers)
       end
 
       private

--- a/spec/unit/open_search/aws/sigv4_client_spec.rb
+++ b/spec/unit/open_search/aws/sigv4_client_spec.rb
@@ -79,5 +79,23 @@ describe OpenSearch::Aws::Sigv4Client do
       client.perform_request('GET', '/_stats', {}, '', {})
       expect(client).not_to have_received(:open_search_validation_request)
     end
+
+    it 'passes the same body to sign_request and super' do
+      body = {
+        char_filter: {
+          test: {
+            type: "mapping",
+            mappings: [ "’ => '" ]
+          }
+        }
+      }
+      signature_body = body.to_json
+
+      expect(signer).to receive(:sign_request).with(a_hash_including(body: signature_body)).and_call_original
+
+      expect(transport_double).to receive(:perform_request).with('GET', '/', {}, signature_body, kind_of(Hash))
+
+      client.perform_request('GET', '/', {}, body, {})
+    end
   end
 end

--- a/spec/unit/open_search/aws/sigv4_client_spec.rb
+++ b/spec/unit/open_search/aws/sigv4_client_spec.rb
@@ -84,18 +84,18 @@ describe OpenSearch::Aws::Sigv4Client do
       body = {
         char_filter: {
           test: {
-            type: "mapping",
-            mappings: [ "’ => '" ]
+            type: 'mapping',
+            mappings: ["’ => '"]
           }
         }
       }
       signature_body = body.to_json
 
-      expect(signer).to receive(:sign_request).with(a_hash_including(body: signature_body)).and_call_original
-
-      expect(transport_double).to receive(:perform_request).with('GET', '/', {}, signature_body, kind_of(Hash))
+      allow(signer).to receive(:sign_request).with(a_hash_including(body: signature_body)).and_call_original
 
       client.perform_request('GET', '/', {}, body, {})
+
+      expect(transport_double).to have_received(:perform_request).with('GET', '/', {}, signature_body, kind_of(Hash))
     end
   end
 end


### PR DESCRIPTION
### Description
This PR fixes an AWS Sigv4 mismatch when the request body contains certain characters (possibly in the presence of certain instrumentation libraries?)

In my case this seems to happen because the Sigv4 and the base class's perform_request stringify the body differently. The base class code that does this seems to be here: https://github.com/opensearch-project/opensearch-ruby/blob/main/lib/opensearch/transport/transport/base.rb#L237

I suppose another option would be to make the Sigv4 class use that same method to stringify the body.

### Issues Resolved
This solves my instance of https://github.com/opensearch-project/opensearch-ruby/issues/141 but it may not solve everyone else's.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
