### PR TITLE
Change tokenId for the Release Jenkins Job

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -4,7 +4,7 @@ lib = library(identifier: 'jenkins@1.4.2', retriever: modernSCM([
 ]))
 
 standardReleasePipelineWithGenericTrigger(
-    tokenIdCredential: 'jenkins-opensearch-ruby-generic-webhook-token',
+    tokenIdCredential: 'jenkins-opensearch-ruby-aws-sigv4-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-ruby repository causing this workflow to run',
     downloadReleaseAsset: true,
     publishRelease: true) {


### PR DESCRIPTION
### Description
Update the new tokenId for opensearch-ruby-aws-sigv4 in the Release job
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
