### PR TITLE
Remove 2.0 from the list of test as not maintained

### DIFF
--- a/.github/workflows/test_unreleased.yml
+++ b/.github/workflows/test_unreleased.yml
@@ -17,7 +17,6 @@ jobs:
         entry:
           - { ruby_version: '3.1', opensearch_ref: '1.x' }
           - { ruby_version: '3.1', opensearch_ref: '2.x' }
-          - { ruby_version: '3.1', opensearch_ref: '2.0' }
           - { ruby_version: '3.1', opensearch_ref: 'main' }
 
     steps:


### PR DESCRIPTION
### Description
Remove 2.0 from the list of test as not maintained

### Issues Resolved
https://github.com/opensearch-project/opensearch-ruby-aws-sigv4/pull/43#issuecomment-2259338812

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
