### PR TITLE
Exclude `ignore` param when creating SigV4 signatures

### DIFF
--- a/.github/workflows/change_log.yml
+++ b/.github/workflows/change_log.yml
@@ -8,7 +8,7 @@ jobs:
   verify-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -18,7 +18,7 @@ jobs:
         cluster-version: [ "1.0.0", "1.3.1", "2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0" ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Increase system limits
         run: |
           sudo swapoff -a

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.3 ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Increase system limits
         run: |
           sudo swapoff -a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: get_approvers
         run: |
           echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT

--- a/.github/workflows/test_unreleased.yml
+++ b/.github/workflows/test_unreleased.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.entry.ruby_version }}
       - name: Checkout OpenSearch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: opensearch-project/OpenSearch
           ref: ${{ matrix.entry.opensearch_ref }}
@@ -37,7 +37,7 @@ jobs:
 
       - name: Restore cached build
         id: cache-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: opensearch/distribution/archives/linux-tar/build/distributions
           key: ${{ steps.get-key.outputs.key }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Save cached build
         if: steps.cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: opensearch/distribution/archives/linux-tar/build/distributions
           key: ${{ steps.get-key.outputs.key }}
@@ -74,7 +74,7 @@ jobs:
           exit 1
 
       - name: Checkout Ruby Client
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ruby-client
 
@@ -89,7 +89,7 @@ jobs:
 
       - name: Save server logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: opensearch-logs-${{ matrix.entry.opensearch_ref }}-ruby-${{ matrix.entry.ruby_version }}
           path: |

--- a/.github/workflows/test_unreleased.yml
+++ b/.github/workflows/test_unreleased.yml
@@ -20,9 +20,17 @@ jobs:
           - { ruby_version: '3.1', opensearch_ref: 'main' }
 
     steps:
+      - uses: actions/setup-java@v4
+        with:
+          java-version: |
+            ${{ contains(matrix.entry.opensearch_ref, '1.x') && '11' || '21' }}
+          distribution: 'temurin'
+          check-latest: true
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.entry.ruby_version }}
+
       - name: Checkout OpenSearch
         uses: actions/checkout@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 - Made CI workflows compatible with OS 2.12 and later. ([#40](https://github.com/opensearch-project/opensearch-ruby-aws-sigv4/pull/40))
+- Exclude `ignore` param when creating SigV4 signatures. ([#46](https://github.com/opensearch-project/opensearch-ruby-aws-sigv4/pull/46))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/lib/opensearch-aws-sigv4.rb
+++ b/lib/opensearch-aws-sigv4.rb
@@ -79,6 +79,8 @@ module OpenSearch
       def signature_url(path, params)
         host = @transport.transport.hosts.dig(0, :host)
         path = "/#{path}" unless path.start_with?('/')
+        params = params.clone
+        params.delete(:ignore)
         query_string = params.empty? ? '' : Faraday::Utils::ParamsHash[params].to_query.to_s
         URI::HTTP.build(host: host, path: path, query: query_string)
       end

--- a/opensearch-aws-sigv4.gemspec
+++ b/opensearch-aws-sigv4.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'aws-sigv4', '>= 1'
-  s.add_dependency 'opensearch-ruby', '>= 1.0.1'
+  s.add_dependency 'opensearch-ruby', '>= 1.0.1', '< 4.0'
 end

--- a/spec/unit/open_search/aws/sigv4_client_spec.rb
+++ b/spec/unit/open_search/aws/sigv4_client_spec.rb
@@ -74,6 +74,12 @@ describe OpenSearch::Aws::Sigv4Client do
       expect(transport_double).to have_received(:perform_request).with('GET', '/', {}, '', signed_headers)
     end
 
+    it 'excludes the `ignore` param to make a signature' do
+      output = client.perform_request('GET', '/', { ignore: 404 }, '', {})
+      expect(output).to eq(response)
+      expect(transport_double).to have_received(:perform_request).with('GET', '/', { ignore: 404 }, '', signed_headers)
+    end
+
     it 'skips the opensearch verification' do
       allow(client).to receive(:open_search_validation_request)
       client.perform_request('GET', '/_stats', {}, '', {})


### PR DESCRIPTION
### Description

I'm using 1.2.1 of this gem with [opensearch-ruby@3.4.0](https://github.com/opensearch-project/opensearch-ruby/tree/3.4.0).

When sending a request using `opensearch-ruby`, specifying the `ignore` parameter causes it to be included in the query string during signature creation. This leads to a `403` error when executing:

```ruby
config = ...
signer = ...
client = OpenSearch::Aws::Sigv4Client.new(config, signer)
client.indices.delete(index: 'test', ignore: 404)
```

(The same error would occur during anything else request that is available the `ignore` param)

The reason is that SigV4 includes the `ignore` parameter in the query string when generating the signature.

In fact, at the lower-level transport implementation, the parameter is removed from params before the request is sent: https://github.com/opensearch-project/opensearch-ruby/blob/3.4.0/lib/opensearch/transport/transport/base.rb#L285

Thus, this library should also remove the ignore parameter before creating the signature.

### Issues Resolved

n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
