### PR TITLE
Removed support for Ruby 2.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.4
+          ruby-version: 2.5
           bundler-cache: true
       - run: bundle exec rubocop

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.3 ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.3 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: enable
 
 RSpec/ImplicitExpect:
@@ -28,4 +28,7 @@ Metrics:
   Enabled: false
 
 Layout/HashAlignment:
+  Enabled: false
+
+Gemspec/RequireMFA:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Made CI workflows compatible with OS 2.12 and later. ([#40](https://github.com/opensearch-project/opensearch-ruby-aws-sigv4/pull/40))
 - Exclude `ignore` param when creating SigV4 signatures. ([#46](https://github.com/opensearch-project/opensearch-ruby-aws-sigv4/pull/46))
+### Removed
+- Removed support for ruby 2.4 ([58](https://github.com/opensearch-project/opensearch-ruby-aws-sigv4/pull/58))
 ### Security
 - Upgraded `rubocop-rspec` to the latest 2.x version to resolve CVE in its rexml dependency ([#42](https://github.com/opensearch-project/opensearch-ruby-aws-sigv4/pull/42))
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,24 +15,12 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'bundler', '~> 2'
-gem 'rake', '~> 13'
-gem 'yard', '~> 0.9', '>= 0.9.35'
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4') && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
-  gem 'rubocop', '~> 1.12.1'
-  gem 'rubocop-rake', '~> 0.5.1'
-  gem 'rubocop-rspec', '~> 2'
-  gem 'simplecov', '~> 0.18.5'
-else
-  # We need to disable Bundler/DuplicatedGem only because of rubocop 1.12.1.
-  # Rubocop 1.28 allows conditional declaration of gems.  See: https://docs.rubocop.org/rubocop/cops_bundler.html#bundlerduplicatedgem
-  gem 'rubocop', '~> 1.28' # rubocop:disable Bundler/DuplicatedGem, Lint/RedundantCopDisableDirective
-  gem 'rubocop-rake', '~> 0.6' # rubocop:disable Bundler/DuplicatedGem, Lint/RedundantCopDisableDirective
-  gem 'rubocop-rspec', '~> 2.10' # rubocop:disable Bundler/DuplicatedGem, Lint/RedundantCopDisableDirective
-  gem 'simplecov', '~> 0.22' # rubocop:disable Bundler/DuplicatedGem, Lint/RedundantCopDisableDirective
-end
-
-gem 'rspec', '~> 3'
-gem 'timecop', '~> 0.9'
-
 gem 'pry', '~> 0.14'
+gem 'rake', '~> 13'
+gem 'rspec', '~> 3'
+gem 'rubocop', '~> 1.28'
+gem 'rubocop-rake', '~> 0.6'
+gem 'rubocop-rspec', '~> 2.10'
+gem 'simplecov', '~> 0.22'
+gem 'timecop', '~> 0.9'
+gem 'yard', '~> 0.9', '>= 0.9.35'

--- a/opensearch-aws-sigv4.gemspec
+++ b/opensearch-aws-sigv4.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
     s.cert_chain  = ['.github/opensearch-rubygems.pem']
   end
 
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 2.5'
 
   s.add_dependency 'aws-sigv4', '>= 1'
   s.add_dependency 'opensearch-ruby', '>= 1.0.1', '< 4.0'


### PR DESCRIPTION
Dropping support for Ruby 2.4 as dependencies of this gem (aws-sigv4, aws-eventstream) now [require ruby 2.5](https://github.com/aws/aws-sdk-ruby/pull/2951/files) at minimum, which has [prevented us from releasing this gem](https://build.ci.opensearch.org/blue/organizations/jenkins/release-opensearch-ruby-aws-sigv4/detail/release-opensearch-ruby-aws-sigv4/3/pipeline/).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
