### PR TITLE
Update release.JenkinsFile to use ruby 3.1.2 for releases

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -10,6 +10,7 @@ standardReleasePipelineWithGenericTrigger(
     publishRelease: true) {
         publishToRubyGems(
             publicCertPath: ".github/opensearch-rubygems.pem",
+            rubyVersion: "3.1.2",
             apiKeyCredentialId: 'jenkins-opensearch-aws-sigv4-api-key'
             )
     }


### PR DESCRIPTION
### Description
Update release.JenkinsFile to use ruby 3.1.2 for releases

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/5417

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
