### PR TITLE
Refactor signer to avoid having to wrap it.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,6 @@ Layout/HashAlignment:
 
 Gemspec/RequireMFA:
   Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,13 @@
 # CHANGELOG
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-
-## Unreleased
+## Unreleased (2.0.0)
 ### Added
+- Add compatibility with opensearch-ruby 4.0.
 ### Changed
 ### Deprecated
 ### Removed
-### Fixed
-### Security
-
----
-
-## 2.0.0
-### Added
-### Changed
-- Compatibility with opensearch-ruby 4.0
-### Deprecated
-### Removed
-- `OpenSearch::AWS::Sigv4Client` is removed. No longer extend `OpenSearch::Client` and use `OpenSearch::Aws::Sigv4RequestSigner` instead. (See [UPGRADING.md](UPGRADING.md))
+- The `OpenSearch::AWS::Sigv4Client` class has been removed and will no longer extend `OpenSearch::Client`, use `OpenSearch::Aws::Sigv4RequestSigner` instead. See [UPGRADING.md](UPGRADING.md).
 ### Fixed
 ### Security
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ require 'bundler/gem_tasks'
 task(:default) { system 'rake --tasks' }
 
 desc 'Run unit tests'
-task test: 'test:spec'
+task test: 'test:unit'
 
 # ----- Test tasks ------------------------------------------------------------
 require 'rspec/core/rake_task'

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,20 +1,23 @@
 # Upgrading
 
-## Upgrading to 2.0
+## Upgrading to >= 2.0
 
 ### Breaking Changes
+
 - The class `OpenSearch::Aws::Sigv4Client` has been removed.
 - Code that extends `OpenSearch::Aws::Sigv4Client` must now use `OpenSearch::Client` with a `OpenSearch::Aws::Sigv4RequestSigner`.
 
 ### Migration
+
 1. Remove any references to `OpenSearch::Aws::Sigv4Client`.
-2. Use `OpenSearch::Client` and pass `request_signer: OpenSearch::Aws::Sigv4RequestSigner.new(your_signer)`.
+2. Use `OpenSearch::Client` and pass an instance of `OpenSearch::Aws::Sigv4RequestSigner` to `request_signer`.
 
 ### Example
+
 Below is a brief example of updating your client configuration:
 
 ```ruby
-signer = Aws::Sigv4::Signer.new(
+request_signer = OpenSearch::Aws::Sigv4RequestSigner.new(
   service: 'es',
   region: 'us-west-2',
   access_key_id: 'key_id',
@@ -23,21 +26,21 @@ signer = Aws::Sigv4::Signer.new(
 
 client = OpenSearch::Client.new({
   host: 'https://your.amz-managed-opensearch.domain',
-  request_signer: OpenSearch::Aws::Sigv4RequestSigner.new(signer)
+  request_signer: request_signer
 })
 ```
 
 ### Debug Logging
-Since 2.0, the client logs the contents of the signature at `debug` level using the `logger` passed to `OpenSearch::Client`.
-If you do not provide a logger, the client will use a default `debug`-level logger. To ensure safe logging in a production environment, explicitly pass a logger configured with a higher level (e.g. `INFO`):
+
+By default, the signer will use the logger from the `opensearch-ruby` gem. To ensure safe logging in a production environment, make sure its level is set to `INFO` to avoid logging debug-level signed headers.
 
 ```ruby
 logger = Logger.new
 logger.level = Logger::INFO
 
-client = OpenSearch::Client.new({
+client = OpenSearch::Client.new(
   host: 'https://your.amz-managed-opensearch.domain',
-  request_signer: OpenSearch::Aws::Sigv4RequestSigner.new(signer),
+  request_signer: OpenSearch::Aws::Sigv4RequestSigner.new(...),
   logger: logger
-})
+)
 ```

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,8 @@
 
 # frozen_string_literal: true
 
-require_relative '../lib/opensearch-aws-sigv4'
+require 'opensearch-aws-sigv4'
+require 'aws-sigv4'
 require 'rspec'
 
 OPENSEARCH_URL = ENV.fetch('TEST_OPENSEARCH_SERVER', nil) || "http://localhost:#{ENV.fetch('PORT', nil) || 9200}"


### PR DESCRIPTION
### Description

This is what I am thinking about from the discussion in #62. We don't want to inherit to avoid overriding method signatures, but we can delegate everything except `sign_request`. Feels much simpler for the user.

I think the logger notes are incorrect. There's no logger initialization here, and I couldn't find where opensearch-ruby initializes the logger at `DEBUG`, but I could be wrong.

Should we also rename `OpenSearch::Aws::Sigv4RequestSigner` to `OpenSearch::Aws::Sigv4::Signer` to match  `Aws::Sigv4::Signer`?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
