### PR TITLE
Fixed Reusable Workflow Evocation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,18 @@ on:
       - "*"
 
 jobs:
+  dry_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/dry_release.yml
   draft_release:
+    needs: dry_release
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write
       issues: write
     steps:
-      - uses: .github/workflows/dry_release.yml
       - name: Checkout Repository
         uses: actions/checkout@v4
       - id: get_approvers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # CHANGELOG
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+
 ## Unreleased
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
+
+## 2.0.0
 ### Added
 ### Changed
 - Compatibility with opensearch-ruby 4.0


### PR DESCRIPTION
The `dry_release` workflow couldn't be called by the `release` workflow [previously](https://github.com/opensearch-project/opensearch-ruby-aws-sigv4/actions/runs/14225141609). This is an attempt to fix that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
