### PR TITLE
Updated release workflows

### DIFF
--- a/.github/workflows/dry_release.yml
+++ b/.github/workflows/dry_release.yml
@@ -3,7 +3,6 @@ on:
   push: { branches: ["*"], paths-ignore: ['*.md'] }
   pull_request: { branches: ["*"], paths-ignore: ['*.md'] }
   schedule: [{ cron: '0 12 * * 0' }] # Every Sunday at 12:00 UTC
-  workflow_call: {}
 jobs:
   test-gem-release:
     env:
@@ -29,7 +28,6 @@ jobs:
         run: |
           gem build opensearch-aws-sigv4.gemspec
           gem cert --add $GEM_PUBLIC_CERT
-          gem install faraday -v '~> 1'
           gem install opensearch-aws-sigv4-*.gem
           gem uninstall opensearch-aws-sigv4 -x
           gem install opensearch-aws-sigv4-*.gem -P MediumSecurity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,35 @@ on:
 
 jobs:
   dry_release:
+    env:
+      GEM_PRIVATE_KEY: .github/dummy.gem-private_key.pem
+      GEM_PUBLIC_CERT: .github/dummy.gem-public_cert.pem
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/workflows/dry_release.yml
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+          bundler: none
+      - name: Determine Ruby Version
+        run: |
+          set -x
+          min_ruby_version=$(ruby -e 'puts Gem::Specification.load("opensearch-aws-sigv4.gemspec").required_ruby_version.to_s.match(/\d+\.\d+/)[0]')
+          echo "RUBY_VERSION=$min_ruby_version" >> $GITHUB_ENV
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler: latest
+      - name: Build and Install Gem
+        run: |
+          gem build opensearch-aws-sigv4.gemspec
+          gem cert --add $GEM_PUBLIC_CERT
+          gem install opensearch-aws-sigv4-*.gem
+          gem uninstall opensearch-aws-sigv4 -x
+          gem install opensearch-aws-sigv4-*.gem -P MediumSecurity
+          gem uninstall opensearch-aws-sigv4 -x
+          gem install opensearch-aws-sigv4-*.gem -P HighSecurity
+
   draft_release:
     needs: dry_release
     runs-on: ubuntu-latest
@@ -29,7 +55,8 @@ jobs:
           approvers: ${{ steps.get_approvers.outputs.approvers }}
           minimum-approvals: 1
           issue-title: "Release ${{ github.ref_name }}"
-          issue-body: "Please approve or deny the release **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
+          issue-body: "Please approve or deny the release **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}. 
+          The release pipeline for this gem can be found at https://build.ci.opensearch.org/blue/organizations/jenkins/release-opensearch-ruby-aws-sigv4/activity"
           exclude-workflow-initiator-as-approver: true
       - name: Install Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
- The release workflow no longer relies on dry_release workflow (We will turn dry-release workflow into a github action that can be used by other ruby repos later)
- Updated dry release to match the steps on Jenkins
- Added jenkin build link to approval message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
