### PR TITLE
Move dblock to emeritus maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @VijayanB @vamshin @dblock @VachaShah @nhtruong @harshavamsi
+* @VijayanB @vamshin @VachaShah @nhtruong @harshavamsi

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,13 +8,13 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 |-------------------------|-----------------------------------------------|-------------|
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)       | Amazon      |
 | Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)         | Amazon      |
-| Daniel Doubrovkine      | [dblock](https://github.com/dblock)           | Amazon      |
 | Vacha Shah              | [VachaShah](https://github.com/VachaShah)     | Amazon      |
 | Theo Truong             | [nhtruong](https://github.com/nhtruong)       | Amazon      |
 | Harsha Vamsi Kalluri    | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
 
 ## Emeritus
-| Maintainer     | GitHub ID                                       | Affiliation |
-|----------------|-------------------------------------------------|-------------|
-| Rob Sears      | [robsears](https://github.com/robsears)         | Bonsai      |
-| Jayesh Hathila | [jayeshathila](https://github.com/jayeshathila) | Amazon      |
+| Maintainer         | GitHub ID                                       | Affiliation |
+|--------------------|------------------------------------------------------------------------------|
+| Daniel Doubrovkine | [dblock](https://github.com/dblock)             | Independent |
+| Rob Sears          | [robsears](https://github.com/robsears)         | Bonsai      |
+| Jayesh Hathila     | [jayeshathila](https://github.com/jayeshathila) | Amazon      |


### PR DESCRIPTION
## Summary
- Moved dblock to emeritus maintainers section
- Removed dblock from CODEOWNERS

🤖 Generated with [Claude Code](https://claude.com/claude-code)